### PR TITLE
ApiAuth middleware and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /example/.var/
 /vendor/
 composer.lock
+*.db
+*.rdb
+*.local.*

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         }
     },
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "adhocore/jwt": "^0.0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.0",

--- a/example/MicroController.php
+++ b/example/MicroController.php
@@ -24,30 +24,17 @@ class MicroController
     {
         $db = $this->di('db');
 
-        // Assuming we use sqlite for this example
-        // This table is used to test/demonstrate db extension
-        $db->execute('CREATE TABLE IF NOT EXISTS phalcon_ext (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name VARCHAR(25),
-            details VARCHAR(255),
-            status VARCHAR(10)
-        )');
-
-        $db->execute('DELETE FROM phalcon_ext'); // Cleanup so we can test a fresh
-
-        $info['bulk_insert=1'] = (int) $db->insertAsBulk('phalcon_ext', [
-            ['name' => 'name1', 'status' => 'status1'],
-            ['details' => 'detail2', 'name' => 'name2'], // columns dont need to be ordered or balanced
+        $info['bulk_insert=1'] = (int) $db->insertAsBulk('tests', [
+            ['prop_a' => 1, 'prop_c' => 3],
+            ['prop_b' => 2, 'prop_a' => 3],
+            ['prop_c' => 2, 'prop_b' => 1],
         ]);
 
-        $info['count_by[name1]=1']         = $db->countBy('phalcon_ext', ['name' => 'name1']);
-        $info['count_by[name2,detail3]=0'] = $db->countBy('phalcon_ext', [
-            'name'    => 'name1',
-            'details' => 'detail3',
-        ]);
+        $info['count_by[prop_a:1]=1']       = $db->countBy('tests', ['prop_a' => 1]);
+        $info['count_by[prop_b:1,prop_c:3]=0'] = $db->countBy('tests', ['prop_b' => 1, 'prop_c' => 3]);
 
-        $info['upsert=1']            = (int) $db->upsert('phalcon_ext', ['details' => 'detail1'], ['name' => 'name1']);
-        $info['count_by[detail1]=1'] = $db->countBy('phalcon_ext', ['name' => 'name1']);
+        $info['upsert=1']            = (int) $db->upsert('tests', ['prop_b' => 2], ['prop_b' => 1]);
+        $info['count_by[prop_b:2]=1'] = $db->countBy('tests', ['prop_b' => 2]);
 
         return '<pre>' . print_r($info, 1) . '</pre>'
             . '<p>You can check sql logs in <code>example/.var/sql/</code></p>';

--- a/example/MicroController.php
+++ b/example/MicroController.php
@@ -139,4 +139,9 @@ class MicroController
             'response' => $response->getHeaders()->toArray(),
         ]);
     }
+
+    public function authAction()
+    {
+        // Do nothing. (It will be intercepted and handled by ApiAuth middleware).
+    }
 }

--- a/example/MicroController.php
+++ b/example/MicroController.php
@@ -30,10 +30,10 @@ class MicroController
             ['prop_c' => 2, 'prop_b' => 1],
         ]);
 
-        $info['count_by[prop_a:1]=1']       = $db->countBy('tests', ['prop_a' => 1]);
+        $info['count_by[prop_a:1]=1']          = $db->countBy('tests', ['prop_a' => 1]);
         $info['count_by[prop_b:1,prop_c:3]=0'] = $db->countBy('tests', ['prop_b' => 1, 'prop_c' => 3]);
 
-        $info['upsert=1']            = (int) $db->upsert('tests', ['prop_b' => 2], ['prop_b' => 1]);
+        $info['upsert=1']             = (int) $db->upsert('tests', ['prop_b' => 2], ['prop_b' => 1]);
         $info['count_by[prop_b:2]=1'] = $db->countBy('tests', ['prop_b' => 2]);
 
         return '<pre>' . print_r($info, 1) . '</pre>'

--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use Ahc\Jwt\JWT;
 use Phalcon\Cache\Frontend\None as CacheFront;
 use Phalcon\Mvc\View;
 use PhalconExt\Cache\Redis;
@@ -70,6 +71,12 @@ $di->setShared('redis', function () {
 // Since it is registered as FQCN, it is auto aliased when calling `registerAliases()`.
 $di->setShared('validation', Validation::class);
 
+$di->setShared('jwt', function () {
+    $config = $this->get('config')->toArray()['apiAuth']['jwt'];
+
+    return new JWT($config['keys'], $config['algo'], $config['maxAge'], $config['leeway'], $config['passphrase']);
+});
+
 // Aliasing is totally optional. This helps you to leverage power of di->resolve()
 // Alternatively the service name in DI can be used as the name of constructor params in classes
 //  to be resolved and that works without aliasing.
@@ -78,6 +85,7 @@ $di->registerAliases([
     View::class   => 'view',
     Twig::class   => 'twig',
     Mailer::class => 'mailer',
+    JWT::class    => 'jwt',
     // Some like to call it validator!
     'validator'   => 'validation',
 ]);

--- a/example/config.php
+++ b/example/config.php
@@ -11,7 +11,7 @@ return [
         'logPath'        => __DIR__ . '/.var/sql/', // directory
         'addHeader'      => true,
         'backtraceLevel' => 5,
-        'skipFirst'      => 2, // skip create/delete
+        'skipFirst'      => 1, // skip delete
     ],
     'mail' => [
         'driver' => 'null',
@@ -69,6 +69,40 @@ return [
             '/db',
             // or you can use route name without a `/`
             'home',
+        ],
+    ],
+    'apiAuth' => [
+        // 14 days in seconds (http://stackoverflow.com/questions/15564486/why-do-refresh-tokens-expire-after-14-days)
+        'refreshMaxAge'  => 1209600,
+        // Prefix to use in stored tokens (max 4 chars)
+        'tokenPrefix'    => 'RF/',
+        // The route to generate/refresh access tokens.
+        // genrerate: curl -XPOST -d 'grant_type=password&username=&password=' /api/auth
+        // refresh:   curl -XPOST -d 'grant_type=refresh_token&refresh_token=' /api/auth
+        // It can also accept json payload:
+        //   -H 'content-type: application/json' -d {"grant_type":"refresh_token","refresh_token":""}
+        'authUri' => '/api/auth',
+
+        // The permission scopes required for a route
+        'scopes' => [
+            '/some/uri' => 'admin',
+            '/next/uri' => 'user',
+        ],
+
+        // Json Web tokens configuration.
+        'jwt'            => [
+            'keys'       => [
+                // kid => key (first one is default always)
+                'default' => '*((**@$#@@KJJNN!!#D^G&(U)KOIHIYGTFD',
+            ],
+            'algo'       => 'HS256',
+            // 15 minutes in seconds.
+            'maxAge'     => 900,
+            // Grace time in seconds.
+            'leeway'     => 10,
+            'passphrase' => '',
+            // Name of the app/project
+            'issuer'     => 'phalcon-ext',
         ],
     ],
 ];

--- a/example/index.php
+++ b/example/index.php
@@ -4,6 +4,7 @@ use Phalcon\Mvc\Micro as MicroApplication;
 use Phalcon\Mvc\Micro\Collection;
 use Phalcon\Mvc\Router;
 use Phalcon\Mvc\View\Simple as SimpleView;
+use PhalconExt\Http\Middleware\ApiAuth;
 use PhalconExt\Http\Middleware\Cache;
 use PhalconExt\Http\Middleware\Cors;
 use PhalconExt\Http\Middleware\Throttle;
@@ -46,10 +47,11 @@ $app->mount((new Collection)
     // (But not always, simple requests can do without it.)
     ->options('corsheader', 'corsHeaderAction')
     ->get('corsheader', 'corsHeaderAction')
+    ->post('api/auth', 'authAction')
 );
 
 $app->notFound(function () use ($di) {
-    return $di->get('response')->setContent('')->setStatusCode(404);
+    return $di->get('response')->setContent('404 Not Found')->setStatusCode(404);
 });
 
 // For test return the app instance
@@ -57,4 +59,4 @@ if (getenv('APP_ENV') === 'test') {
     return $app;
 }
 
-(new Middlewares([Throttle::class, Cors::class, Cache::class]))->wrap($app);
+(new Middlewares([Throttle::class, ApiAuth::class, Cors::class, Cache::class]))->wrap($app);

--- a/example/readme.md
+++ b/example/readme.md
@@ -16,6 +16,9 @@ touch example/.var/db.db
 # composer
 composer install -o
 
+# setup db
+php example/setup.php
+
 # start redis server
 redis-server &
 

--- a/example/setup.php
+++ b/example/setup.php
@@ -1,0 +1,41 @@
+<?php
+
+$di = require __DIR__ . '/bootstrap.php';
+$db = $di->get('db');
+
+$db->execute('
+CREATE TABLE IF NOT EXISTS tests (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  prop_a VARCHAR(25),
+  prop_b VARCHAR(255),
+  prop_c VARCHAR(10)
+)');
+
+$db->execute('
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username VARCHAR(25),
+  password VARCHAR(100),
+  scopes VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)');
+
+$db->execute('
+CREATE TABLE IF NOT EXISTS tokens (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  type VARCHAR(25),
+  token VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  expire_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+)');
+
+$db->execute('DELETE FROM tests');
+$db->execute('DELETE FROM SQLITE_SEQUENCE WHERE name = "tests"');
+
+$db->execute('DELETE FROM users');
+$db->execute('DELETE FROM SQLITE_SEQUENCE WHERE name = "users"');
+
+$db->execute('DELETE FROM tokens');
+$db->execute('DELETE FROM SQLITE_SEQUENCE WHERE name = "tokens"');

--- a/readme.md
+++ b/readme.md
@@ -586,7 +586,7 @@ $di->setShared('twig', function () {
 // standalone
 $di->get('twig')->render('template.twig', ['view' => 'params']);
 // or as view
-$di->get('twig')->render('template.twig', ['view' => 'params']); // .twig is optional
+$di->get('view')->render('template.twig', ['view' => 'params']); // .twig is optional
 ```
 
 ---

--- a/src/Contract/ApiAuthenticator.php
+++ b/src/Contract/ApiAuthenticator.php
@@ -10,17 +10,69 @@ namespace PhalconExt\Contract;
  */
 interface ApiAuthenticator
 {
+    /**
+     * Configure the authenticator.
+     *
+     * @param array $config Config parameters
+     *
+     * @return void
+     */
     public function configure(array $config);
 
+    /**
+     * Attempt to auhenticate by credential.
+     *
+     * The implementer must know and cache who has been logged for this session.
+     *
+     * @param string $username Login id/username/email etc
+     * @param string $password
+     *
+     * @return bool True on success, false if not.
+     */
     public function byCredential(string $username, string $password): bool;
 
+    /**
+     * Attempt to auhenticate by refresh token.
+     *
+     * The implementer must know and cache who has been logged for this session.
+     *
+     * @param string $refreshToken
+     *
+     * @return bool True on success, false if not.
+     */
     public function byRefreshToken(string $refreshToken): bool;
 
+    /**
+     * Attempt to auhenticate by subject ID.
+     *
+     * The implementer must know and cache who has been logged for this session.
+     *
+     * @param int $subject
+     *
+     * @return bool True on success, false if not.
+     */
     public function bySubject(int $subject): bool;
 
+    /**
+     * Create a new refresh token for currently logged in user.
+     *
+     * The implementer must know and permanently store which token belongs to which user.
+     *
+     * @return string
+     */
     public function createRefreshToken(): string;
 
+    /**
+     * Get the subject ID for use in `sub` claim of JWT. Ideally user ID.
+     *
+     * @return int
+     */
     public function getSubject(): int;
 
+    /**
+     * Get the permission scopes allowed and entertainable by currenlty logged user.
+     *
+     * @return array
+     */
     public function getScopes(): array;
 }

--- a/src/Contract/ApiAuthenticator.php
+++ b/src/Contract/ApiAuthenticator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhalconExt\Contract;
+
+/**
+ * @author  Jitendra Adhikari <jiten.adhikary@gmail.com>
+ * @license MIT
+ *
+ * @link    https://github.com/adhocore/phalcon-ext
+ */
+interface ApiAuthenticator
+{
+    public function configure(array $config);
+
+    public function byCredential(string $username, string $password): bool;
+
+    public function byRefreshToken(string $refreshToken): bool;
+
+    public function bySubject(int $subject): bool;
+
+    public function createRefreshToken(): string;
+
+    public function getSubject(): int;
+
+    public function getScopes(): array;
+}

--- a/src/Di/Extension.php
+++ b/src/Di/Extension.php
@@ -126,8 +126,11 @@ trait Extension
         $allowsNull = $dependency->allowsNull();
 
         // Is a class and needs to be resolved OR is nullable.
-        if ($dependency->getClass() || $allowsNull) {
-            return $this->resolveSubClassOrNullable($dependency->getClass(), $allowsNull);
+        if ($subClass = $dependency->getClass()) {
+            return $this->resolveSubClassOrNullable($subClass->name, $allowsNull);
+        }
+        if ($allowsNull) {
+            return null;
         }
 
         // Use default value.
@@ -141,19 +144,15 @@ trait Extension
     /**
      * Resolve subClass or nullable.
      *
-     * @param mixed $subClass
-     * @param bool  $allowsNull
+     * @param string $subClass
+     * @param bool   $allowsNull
      *
      * @return mixed
      */
-    protected function resolveSubClassOrNullable($subClass = null, bool $allowsNull = false)
+    protected function resolveSubClassOrNullable(string $subClass, bool $allowsNull = false)
     {
-        if (!$subClass && $allowsNull) {
-            return null;
-        }
-
         try {
-            return $this->resolve($subClass->name);
+            return $this->resolve($subClass);
         } catch (\Throwable $e) {
             if (!$allowsNull) {
                 throw $e;

--- a/src/Di/Extension.php
+++ b/src/Di/Extension.php
@@ -139,7 +139,7 @@ trait Extension
     }
 
     /**
-     * Resolve subClass or nullable
+     * Resolve subClass or nullable.
      *
      * @param mixed $subClass
      * @param bool  $allowsNull

--- a/src/Factory/ApiAuthenticator.php
+++ b/src/Factory/ApiAuthenticator.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace PhalconExt\Factory;
+
+use Phalcon\Config;
+use Phalcon\Db\Adapter as Db;
+use Phalcon\Security\Random;
+use PhalconExt\Contract\ApiAuthenticator as Contract;
+
+/**
+ * Factory implementation for ApiAuthenticator. You might want to roll out your own if it doesnt suffice.
+ *
+ * Uses `users` table with `id`, `username`, `password`, `scopes`, `created_at` fields.
+ * And `tokens` table with `id`, `user_id`, `type`, `token`, `created_at`, `expire_at` fields.
+ */
+class ApiAuthenticator implements Contract
+{
+    protected $db;
+
+    protected $user;
+
+    protected $config = [];
+
+    public function __construct(Db $db)
+    {
+        $this->db = $db;
+    }
+
+    public function configure(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function byCredential(string $username, string $password): bool
+    {
+        $this->user = $this->findUser('username', $username, $password);
+
+        return !empty($this->user);
+    }
+
+    protected function findUser(string $column, $value, $password = null): array
+    {
+        $user = $this->db->fetchOne("SELECT * FROM users WHERE $column = ?", \PDO::FETCH_ASSOC, [$value]);
+        $hash = $user['password'] ?? null;
+
+        if ($password && !\password_verify($password, $hash)) {
+            return [];
+        }
+
+        unset($user['password']);
+
+        return $user ?: [];
+    }
+
+    public function byRefreshToken(string $refreshToken): bool
+    {
+        $token = $this->db->fetchOne(
+            'SELECT * FROM tokens WHERE type = ? AND token = ?',
+            \PDO::FETCH_ASSOC,
+            ['refresh', $refreshToken]
+        );
+
+        if (!$token /* @todo check if token expired */) {
+            return false;
+        }
+
+        return $this->bySubject($token['user_id']);
+    }
+
+    public function bySubject(int $subject): bool
+    {
+        $this->user = $this->findUser('id', $subject);
+
+        return !empty($this->user);
+    }
+
+    public function createRefreshToken(): string
+    {
+        $this->mustBeAuthenticated();
+
+        $tokenLen     = \min($this->config['tokenLength'] ?? 0, 32);
+        $prefix       = \substr($this->config['tokenPrefix'] ?? '', 0, 4);
+        $random       = (new Random)->bytes($tokenLen - \strlen($prefix));
+        $refreshToken = $prefix . \bin2hex($random);
+
+        $this->db->insertAsDict('tokens', [
+            'type'    => 'refresh',
+            'token'   => $refreshToken,
+            'user_id' => $this->user['id'],
+        ]);
+
+        return $refreshToken;
+    }
+
+    /**
+     * Throw up if user is not authenticated yet.
+     *
+     * @codeCoverageIgnore
+     *
+     * @throws \LogicException
+     */
+    protected function mustBeAuthenticated()
+    {
+        if (!$this->user) {
+            throw new \LogicException('You must authenticate an user first');
+        }
+    }
+
+    public function getSubject(): int
+    {
+        $this->mustBeAuthenticated();
+
+        return $this->user['id'];
+    }
+
+    public function getScopes(): array
+    {
+        $this->mustBeAuthenticated();
+
+        return \explode(',', $this->user['scopes']);
+    }
+}

--- a/src/Factory/ApiAuthenticator.php
+++ b/src/Factory/ApiAuthenticator.php
@@ -2,7 +2,6 @@
 
 namespace PhalconExt\Factory;
 
-use Phalcon\Config;
 use Phalcon\Db\Adapter as Db;
 use Phalcon\Security\Random;
 use PhalconExt\Contract\ApiAuthenticator as Contract;

--- a/src/Http/BaseMiddleware.php
+++ b/src/Http/BaseMiddleware.php
@@ -49,12 +49,12 @@ abstract class BaseMiddleware
      * Abort with response.
      *
      * @param int    $status
-     * @param string $body
+     * @param mixed  $content If not string, will be json encoded
      * @param array  $headers
      *
      * @return bool Always false
      */
-    protected function abort(int $status, string $body = null, array $headers = []): bool
+    protected function abort(int $status, $content = null, array $headers = []): bool
     {
         $this->stop();
 
@@ -64,7 +64,13 @@ abstract class BaseMiddleware
             $response->setHeader($key, $value);
         }
 
-        $response->setStatusCode($status)->setContent($body)->send();
+        if ($content && !\is_scalar($content)) {
+            $response->setJsonContent($content);
+        } else {
+            $response->setContent($content);
+        }
+
+        $response->setStatusCode($status)->send();
 
         return false;
     }

--- a/src/Http/BaseMiddleware.php
+++ b/src/Http/BaseMiddleware.php
@@ -48,9 +48,9 @@ abstract class BaseMiddleware
     /**
      * Abort with response.
      *
-     * @param int    $status
-     * @param mixed  $content If not string, will be json encoded
-     * @param array  $headers
+     * @param int   $status
+     * @param mixed $content If not string, will be json encoded
+     * @param array $headers
      *
      * @return bool Always false
      */

--- a/src/Http/Middleware/ApiAuth.php
+++ b/src/Http/Middleware/ApiAuth.php
@@ -20,6 +20,7 @@ class ApiAuth extends BaseMiddleware
 {
     protected $configKey = 'apiAuth';
 
+    /** @var ApiAuthenticator */
     protected $authenticator;
 
     public function __construct(ApiAuthenticator $authenticator = null)
@@ -131,17 +132,17 @@ class ApiAuth extends BaseMiddleware
 
     protected function validateScope(Request $request, string $requiredScope = null): bool
     {
-        $jwt = $request->getHeader('Authorization');
-        $msg = 'Permission denied';
+        $claimedScopes = [];
+        $msg           = 'Permission denied';
+        $jwt           = $request->getHeader('Authorization');
 
         try {
             $claimedScopes = $this->getClaimedScopes($jwt);
         } catch (\InvalidArgumentException $e) {
-            $claimedScopes = [];
-            $msg           = $e->getMessage();
+            $msg = $e->getMessage();
         }
 
-        if ($requiredScope && (isset($e) || !\in_array($requiredScope, $claimedScopes))) {
+        if ($requiredScope && !\in_array($requiredScope, $claimedScopes)) {
             return $this->abort(403, $msg);
         }
 

--- a/src/Http/Middleware/ApiAuth.php
+++ b/src/Http/Middleware/ApiAuth.php
@@ -5,8 +5,8 @@ namespace PhalconExt\Http\Middleware;
 use Phalcon\Http\Request;
 use Phalcon\Http\Response;
 use PhalconExt\Contract\ApiAuthenticator;
-use PhalconExt\Http\BaseMiddleware;
 use PhalconExt\Factory\ApiAuthenticator as FactoryAuthenticator;
+use PhalconExt\Http\BaseMiddleware;
 
 /**
  * Check authentication &/or authorization for api requests.

--- a/src/Http/Middleware/ApiAuth.php
+++ b/src/Http/Middleware/ApiAuth.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace PhalconExt\Http\Middleware;
+
+use Phalcon\Http\Request;
+use Phalcon\Http\Response;
+use PhalconExt\Contract\ApiAuthenticator;
+use PhalconExt\Http\BaseMiddleware;
+use PhalconExt\Factory\ApiAuthenticator as FactoryAuthenticator;
+
+/**
+ * Check authentication &/or authorization for api requests.
+ *
+ * @author  Jitendra Adhikari <jiten.adhikary@gmail.com>
+ * @license MIT
+ *
+ * @link    https://github.com/adhocore/phalcon-ext
+ */
+class ApiAuth extends BaseMiddleware
+{
+    protected $configKey = 'apiAuth';
+
+    protected $authenticator;
+
+    public function __construct(ApiAuthenticator $authenticator = null)
+    {
+        parent::__construct();
+
+        $this->authenticator = $authenticator ?? $this->di(FactoryAuthenticator::class);
+
+        if (!$this->di()->has('authenticator')) {
+            $this->di()->setShared('authenticator', $this->authenticator);
+        }
+
+        $this->authenticator->configure($this->config);
+    }
+
+    /**
+     * Handle authentication.
+     *
+     * @param Request  $request
+     * @param Response $response
+     *
+     * @return bool
+     */
+    public function before(Request $request, Response $response): bool
+    {
+        list($routeName, $currentUri) = $this->getRouteNameUri();
+
+        if ($this->shouldGenerate($request, $currentUri)) {
+            return $this->generateToken($request);
+        }
+
+        $requiredScope = $this->config['scopes'][$routeName] ?? $this->config['scopes'][$currentUri] ?? null;
+
+        return $this->validateScope($request, $requiredScope);
+    }
+
+    protected function shouldGenerate(Request $request, string $currentUri): bool
+    {
+        return $request->isPost() && $this->config['authUri'] === $currentUri;
+    }
+
+    protected function generateToken(Request $request)
+    {
+        $payload = $request->getJsonRawBody(true) ?: $request->getPost();
+
+        if (!$this->validateGenerate($payload)) {
+            return $this->abort(401, 'Credentials missing');
+        }
+
+        if (!$this->authenticate($payload)) {
+            return $this->abort(401, 'Credentials invalid');
+        }
+
+        return $this->serve($payload['grant_type']);
+    }
+
+    protected function validateGenerate(array $payload): bool
+    {
+        if (!isset($payload['grant_type'], $payload[$payload['grant_type']])) {
+            return false;
+        }
+
+        if (!\in_array($payload['grant_type'], ['password', 'refresh_token'])) {
+            return false;
+        }
+
+        return 'password' !== $payload['grant_type'] || isset($payload['username']);
+    }
+
+    protected function authenticate(array $payload): bool
+    {
+        if ('refresh_token' === $payload['grant_type']) {
+            return $this->authenticator->byRefreshToken($payload['refresh_token']);
+        }
+
+        return $this->authenticator->byCredential($payload['username'], $payload['password']);
+    }
+
+    protected function serve(string $grantType): bool
+    {
+        $token = [
+            'access_token' => $this->createJWT(),
+            'token_type'   => 'bearer',
+            'expires_in'   => $this->config['jwt']['maxAge'],
+            'grant_type'   => $grantType,
+        ];
+
+        if ($grantType === 'password') {
+            $token['refresh_token'] = $this->authenticator->createRefreshToken();
+        }
+
+        return $this->abort(200, $token);
+    }
+
+    protected function createJWT(): string
+    {
+        $jwt = [
+            'sub'    => $this->authenticator->getSubject(),
+            'scopes' => $this->authenticator->getScopes(),
+        ];
+
+        if ($this->config['jwt']['issuer'] ?? null) {
+            $jwt['iss'] = $this->config['jwt']['issuer'];
+        }
+
+        // 'exp' is automatically added based on `config->apiAuth->jwt->maxAge`!
+        return $this->di('jwt')->encode($jwt);
+    }
+
+    protected function validateScope(Request $request, string $requiredScope = null): bool
+    {
+        $jwt = $request->getHeader('Authorization');
+        $msg = 'Permission denied';
+
+        try {
+            $claimedScopes = $this->getClaimedScopes($jwt);
+        } catch (\InvalidArgumentException $e) {
+            $claimedScopes = [];
+            $msg           = $e->getMessage();
+        }
+
+        if ($requiredScope && (isset($e) || !\in_array($requiredScope, $claimedScopes))) {
+            return $this->abort(403, $msg);
+        }
+
+        return true;
+    }
+
+    protected function getClaimedScopes(string $jwt = null): array
+    {
+        if ('' === $jwt = \str_replace('Bearer ', '', \trim($jwt))) {
+            return [];
+        }
+
+        $decoded = $this->di('jwt')->decode($jwt);
+
+        if ($decoded['sub'] ?? null) {
+            $this->authenticator->bySubject($decoded['sub']);
+        }
+
+        return $decoded['scopes'] ?? [];
+    }
+}

--- a/src/Http/Middlewares.php
+++ b/src/Http/Middlewares.php
@@ -61,8 +61,12 @@ class Middlewares
     protected function handleMicro(Injectable $app)
     {
         $app
-            ->before([$this, 'beforeHandleRequest'])
-            ->after([$this, 'beforeSendResponse']);
+            ->before(function () {
+                return $this->relay('before');
+            })
+            ->after(function () {
+                return $this->relay('after');
+            });
 
         return $this->handleApp($app);
     }

--- a/tests/Db/ExtensionTest.php
+++ b/tests/Db/ExtensionTest.php
@@ -14,13 +14,6 @@ class ExtensionTest extends TestCase
         self::$db = new Sqlite([
             'dbname' => __DIR__ . '/../../example/.var/db.db',
         ]);
-
-        self::$db->execute('CREATE TABLE IF NOT EXISTS tests (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            prop_a VARCHAR(25),
-            prop_b VARCHAR(255),
-            prop_c VARCHAR(10)
-        )');
     }
 
     public function setUp()

--- a/tests/Db/LoggerTest.php
+++ b/tests/Db/LoggerTest.php
@@ -35,14 +35,6 @@ class LoggerTest extends TestCase
         $evm->attach('db', new Logger(['enabled' => false]));
 
         self::$db->setEventsManager($evm);
-
-        self::$db->execute('CREATE TABLE IF NOT EXISTS tests (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            prop_a VARCHAR(25),
-            prop_b VARCHAR(255),
-            prop_c VARCHAR(10)
-        )');
-
         self::$log = __DIR__ . '/../../example/.var/sql/' . date('Y-m-d') . '.sql';
     }
 

--- a/tests/Http/Middleware/ApiAuthTest.php
+++ b/tests/Http/Middleware/ApiAuthTest.php
@@ -21,7 +21,6 @@ class ApiAuthTest extends WebTestCase
             ->assertStatusCode(401)
             ->assertResponseContains('Credentials missing');
 
-
         $credentials = ['grant_type' => 'password'];
 
         $this->doRequest('POST /api/auth', $credentials)
@@ -103,7 +102,7 @@ class ApiAuthTest extends WebTestCase
         $this->assertSame(1, $this->di('authenticator')->getSubject());
 
         // With invalid jwt
-        $this->doRequest('/corsheader', [], ['Authorization' => "Bearer invalid"])
+        $this->doRequest('/corsheader', [], ['Authorization' => 'Bearer invalid'])
             ->assertResponseNotOk()
             ->assertStatusCode(403)
             ->assertResponseContains('Invalid token');

--- a/tests/Http/Middleware/ApiAuthTest.php
+++ b/tests/Http/Middleware/ApiAuthTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace PhalconExt\Test\Http\Middleware;
+
+use PhalconExt\Http\Middleware\ApiAuth;
+use PhalconExt\Test\WebTestCase;
+
+class ApiAuthTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->middlewares = [ApiAuth::class];
+    }
+
+    public function test_auth_generate_401()
+    {
+        $this->doRequest('POST /api/auth', ['grant_type' => 'invalid', 'invalid' => 1])
+            ->assertResponseNotOk()
+            ->assertStatusCode(401)
+            ->assertResponseContains('Credentials missing');
+
+
+        $credentials = ['grant_type' => 'password'];
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseNotOk()
+            ->assertStatusCode(401)
+            ->assertResponseContains('Credentials missing');
+
+        $credentials += ['username' => 'adhocore', 'password' => 123456];
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseNotOk()
+            ->assertStatusCode(401)
+            ->assertResponseContains('Credentials invalid');
+    }
+
+    public function test_auth_generate_200()
+    {
+        $credentials = ['grant_type' => 'password', 'username' => 'adhocore', 'password' => 123456];
+
+        $this->ensureUser($credentials + ['scopes' => 'user']);
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseOk()
+            ->assertStatusCode(200)
+            ->assertResponseKeys(['access_token', 'refresh_token'])
+            ->assertResponseKey('grant_type', 'password')
+            ->assertResponseKey('expires_in', $this->config('apiAuth.jwt.maxAge'));
+
+        return $this->getJson();
+    }
+
+    public function test_refresh_401()
+    {
+        $credentials = ['grant_type' => 'refresh_token'];
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseNotOk()
+            ->assertStatusCode(401)
+            ->assertResponseContains('Credentials missing');
+
+        $credentials += ['refresh_token' => 'invalid'];
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseNotOk()
+            ->assertStatusCode(401)
+            ->assertResponseContains('Credentials invalid');
+    }
+
+    /** @depends test_auth_generate_200 */
+    public function test_refresh_200($token)
+    {
+        $credentials = ['grant_type' => 'refresh_token', 'refresh_token' => $token['refresh_token']];
+
+        $this->doRequest('POST /api/auth', $credentials)
+            ->assertResponseOk()
+            ->assertResponseKeys(['access_token'])
+            ->assertResponseKey('grant_type', 'refresh_token')
+            ->assertResponseKey('expires_in', $this->config('apiAuth.jwt.maxAge'));
+
+        return $this->getJson()['access_token'];
+    }
+
+    /** @depends test_auth_generate_200 */
+    public function test_auth($token)
+    {
+        $this->configure('apiAuth', ['scopes' => ['/corsheader' => 'user']]);
+
+        // Without jwt
+        $this->doRequest('/corsheader')
+            ->assertResponseNotOk()
+            ->assertStatusCode(403)
+            ->assertResponseContains('Permission denied');
+
+        // With jwt
+        $this->doRequest('/corsheader', [], ['Authorization' => "Bearer {$token['access_token']}"])
+            ->assertResponseOk()
+            ->assertResponseKeys(['request', 'response']);
+
+        $this->assertSame(1, $this->di('authenticator')->getSubject());
+
+        // With invalid jwt
+        $this->doRequest('/corsheader', [], ['Authorization' => "Bearer invalid"])
+            ->assertResponseNotOk()
+            ->assertStatusCode(403)
+            ->assertResponseContains('Invalid token');
+    }
+
+    protected function ensureUser(array $data)
+    {
+        $data['password'] = password_hash($data['password'], PASSWORD_BCRYPT);
+
+        $this->di('db')->upsert('users', \array_intersect_key($data, [
+            'username' => true, 'password' => true, 'scopes' => true,
+        ]), ['username' => $data['username']]);
+    }
+}

--- a/tests/Validation/ExistenceTest.php
+++ b/tests/Validation/ExistenceTest.php
@@ -6,30 +6,15 @@ use PhalconExt\Test\WebTestCase;
 
 class ExistenceTest extends WebTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->di('db')->execute('CREATE TABLE IF NOT EXISTS tests (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            prop_a VARCHAR(25),
-            prop_b VARCHAR(255),
-            prop_c VARCHAR(10)
-        )');
-
-        $this->di('db')->execute('DELETE FROM tests');
-        $this->di('db')->execute('DELETE FROM SQLITE_SEQUENCE WHERE name = "tests"');
-    }
-
     public function test_validate_without_options()
     {
         $rules = ['tests' => 'required|exist'];
-        $vldtr = $this->di('validation')->run($rules, ['tests' => 1]);
+        $vldtr = $this->di('validation')->run($rules, ['tests' => 0]);
 
         $this->assertFalse($vldtr->pass());
 
         $this->di('db')->insertAsDict('tests', ['prop_a' => 'A']);
-        $vldtr = $this->di('validation')->run($rules, ['tests' => 1]);
+        $vldtr = $this->di('validation')->run($rules, ['tests' => $this->di('db')->lastInsertId()]);
 
         $this->assertTrue($vldtr->pass());
     }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -178,4 +178,33 @@ class WebTestCase extends TestCase
 
         return $code === null ? 200 : (int) substr($code, 0, 3);
     }
+
+    protected function assertResponseKey($key, $value = null)
+    {
+        $this->assertArrayHasKey($key, $json = $this->getJson());
+
+        if (func_get_args() === 2) {
+            $this->assertEquals($json[$key], $value);
+        }
+
+        return $this;
+    }
+
+    protected function assertResponseKeys(array $keys)
+    {
+        $json = $this->getJson();
+
+        foreach ($keys as $key) {
+            $this->assertArrayHasKey($key, $json);
+        }
+
+        return $this;
+    }
+
+    protected function getJson()
+    {
+        $this->assertResponseJson();
+
+        return json_decode($this->response->getContent(), true);
+    }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -43,15 +43,19 @@ class WebTestCase extends TestCase
      */
     protected function doRequest(string $uri, array $parameters = [], array $headers = []): self
     {
+        $method = 'GET';
+
         if ($uri[0] !== '/') {
             list($method, $uri) = explode(' ', $uri, 2);
         }
 
-        $parameters['_url']        = $uri;
-        $_SERVER['REQUEST_METHOD'] = $method ?? 'GET';
-        $_SERVER['QUERY_STRING']   = http_build_query($parameters);
-        $_SERVER['REQUEST_URI']    = '/?' . $_SERVER['QUERY_STRING'];
-        $_GET                      = $parameters;
+        $_GET                      = ['_url' => $uri];
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_REQUEST                  = $parameters;
+
+        $method === 'POST' ? $_POST = $parameters : $_GET += $parameters;
+        $_SERVER['QUERY_STRING']    = http_build_query($_GET);
+        $_SERVER['REQUEST_URI']     = '/?' . $_SERVER['QUERY_STRING'];
 
         $headerKeys = [];
         foreach ($headers as $key => $value) {
@@ -107,14 +111,14 @@ class WebTestCase extends TestCase
 
     protected function assertResponseOk(): self
     {
-        $this->assertContains($this->responseCode(), [null, 200]);
+        $this->assertContains($this->responseCode(), [204, 200]);
 
         return $this;
     }
 
     protected function assertResponseNotOk(): self
     {
-        $this->assertNotContains($this->responseCode(), [null, 200]);
+        $this->assertNotContains($this->responseCode(), [204, 200]);
 
         return $this;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
 putenv('APP_ENV=test');
+
+require_once __DIR__ . '/../example/setup.php';


### PR DESCRIPTION
closes #9 

- api auth middleware
- api authenticator interface with factory implementation
- `abort()` in middleware can now output json content
- di:resolve no longer throws for nullable sub class as dependency
- gitignore more stuffs
